### PR TITLE
Fix bug causing tidy.survreg to fail

### DIFF
--- a/R/survival_tidiers.R
+++ b/R/survival_tidiers.R
@@ -620,9 +620,10 @@ tidy.survreg <- function(x, conf.level = .95, ...) {
     ret
     
     # add confidence interval
-    CI <- unrowname(stats::confint(x, level = conf.level))
+    CI <- stats::confint(x, level = conf.level)
     colnames(CI) <- c("conf.low", "conf.high")
-    cbind(ret, CI)
+    CI <- cbind(term = row.names(CI), CI)
+    merge(ret, CI, all.x = TRUE, sort = FALSE)
 }
 
 

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -45,6 +45,27 @@ test_that("tidy.nls works", {
     expect_equal(td$term, c("a", "b", "c"))
 })
 
+test_that("tidy.survreg works", {
+    # prepare data
+    df <- mtcars
+    df$lwr <- floor(mtcars$mpg)
+    df$upr <- ceiling(mtcars$mpg)
+    
+    # weibull fit (has an extra scale parameter)
+    weibull.fit <- survival::survreg(Surv(lwr, upr, type = "interval2") ~ wt, 
+                           data = df, dist = "weibull")
+    td = tidy(weibull.fit)
+    check_tidy(td, exp.row = 3)
+    expect_equal(td$term, c("(Intercept)", "wt", "Log(scale)"))
+    
+    # exponential fit (scale = 1)
+    exp.fit <- survival::survreg(Surv(lwr, upr, type = "interval2") ~ wt, 
+                       data = df, dist = "exponential")
+    td2 = tidy(exp.fit)
+    check_tidy(td2, exp.row = 2)
+    expect_equal(td2$term, c("(Intercept)", "wt"))
+})
+
 
 context("tidying hypothesis tests")
 


### PR DESCRIPTION
`survreg` families with a scale parameter fail to produce tidy output, due to the fact that the length of the coefficients in `summary()` exceed the length of the `confint()` output.

The example given in the `?tidy.survreg` uses a model with the exponential family, which works fine. However, other distributions such as the Weibull family will throw an error if you try to use `tidy`. This is because the `summary` method produces an additional coefficient estimate `Log(scale)`, which is not produced in the `confint` method. When the two are merged using `cbind`, this causes an error.
