### PR TITLE
tidy.lm with quick=T now returns terms as characters, not factors

### DIFF
--- a/R/lm_tidiers.R
+++ b/R/lm_tidiers.R
@@ -132,7 +132,7 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = .95,
                     exponentiate = FALSE, quick = FALSE, ...) {
     if (quick) {
         co <- stats::coef(x)
-        ret <- data.frame(term = names(co), estimate = unname(co))
+        ret <- data.frame(term = names(co), estimate = unname(co), stringsAsFactors = FALSE)
         return(process_lm(ret, x, conf.int = FALSE, exponentiate = exponentiate))
     }
     s <- summary(x)


### PR DESCRIPTION
Addresses issue #188 

The option `quick=T` in `tidy.lm` now returns the `term` as character, consistently with the behavior of `tidy.lm`. 
