### PR TITLE
Fix glance.rqs

### DIFF
--- a/R/rq_tidiers.R
+++ b/R/rq_tidiers.R
@@ -97,7 +97,15 @@ glance.rq <- function(x,...){
 }
 
 #' @export
-glance.rqs <- glance.rq
+glance.rqs <- function(x,...){
+    n <- length(fitted(x))
+    s <- summary(x)
+    data.frame(tau = x[["tau"]],
+               logLik = logLik(x),
+               AIC = AIC(x),
+               BIC = AIC(x,k = log(n)),
+               df.residual = vapply(s, function(x) x[["rdf"]], integer(1)))
+}
 
 #' @rdname rq_tidiers
 #' 


### PR DESCRIPTION
Take the following example:

```
mod_rq <- quantreg::rq(speed ~ dist, cars, tau=c(0.25, 0.75))
glance(mod_rq)
```

> Error in data.frame(tau = x[["tau"]], logLik = logLik(x), AIC = AIC(x),  : 
  arguments imply differing number of rows: 2, 0

`glance.rq(mod_rq)` works just fine for single models e.g. `tau = atomic_double` but for multiple values `glance.rq(mod_rq)` fails.