### PR TITLE
bugfix in tidy.lm

### DIFF
--- a/R/lm_tidiers.R
+++ b/R/lm_tidiers.R
@@ -291,6 +291,12 @@ process_lm <- function(ret, x, conf.int = FALSE, conf.level = .95,
     if (conf.int) {
         # avoid "Waiting for profiling to be done..." message
         CI <- suppressMessages(stats::confint(x, level = conf.level))
+        # Handle case if regression is rank deficient
+        p <- x$rank
+        if (!is.null(p)) {
+            piv <- x$qr$pivot[seq_len(p)]
+            CI <- CI[piv, , drop = FALSE]
+        }
         colnames(CI) = c("conf.low", "conf.high")
         ret <- cbind(ret, trans(unrowname(CI)))
     }

--- a/tests/testthat/test-lm.R
+++ b/tests/testthat/test-lm.R
@@ -16,6 +16,12 @@ test_that("tidy.lm works", {
     expect_warning(tidy(lmfit2, exponentiate = TRUE))
 })
 
+test_that("tidy.lm with confint = TRUE works even if rank-deficient", {
+    d <- data.frame(y = rnorm(4), x = letters[seq_len(4)])
+    expect_is(tidy(lm(y ~ x, data = d), confint = TRUE),
+              "data.frame")
+})
+
 test_that("tidy.glm works", {
     glmfit <- glm(am ~ wt, mtcars, family="binomial")
     td = tidy(glmfit)


### PR DESCRIPTION
If the regression is rank deficient and `confint = TRUE`, then `tidy()` will throw an unhelpful error like,
```
Error in data.frame(..., check.names = FALSE) :
  arguments imply differing number of rows: 199, 535
Calls: <Anonymous> ... tidy.lm -> process_lm -> cbind -> cbind -> data.frame
```

This fixes this by dropping the dropped coefficient from the confidence intervals prior to binding them to the results. The approach used in this patch is the same one that appears in `summary.lm` to handle dropped coefficients.