### PR TITLE
Added optional index unwrapping to tidy/rstan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,4 +91,4 @@ URL: http://github.com/tidyverse/broom
 BugReports: http://github.com/tidyverse/broom/issues
 VignetteBuilder: knitr
 License: MIT + file LICENSE
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/mcmc_tidiers.R
+++ b/R/mcmc_tidiers.R
@@ -10,6 +10,7 @@
 #' @param droppars Parameters not to include in the output (such
 #' as log-probability information)
 #' @param rhat,ess (logical) include Rhat and/or effective sample size estimates?
+#' @param index Add index column, remove index from term
 #' @param ... unused
 #' 
 #' @name mcmc_tidiers
@@ -21,13 +22,13 @@
 #' # Using example from "RStan Getting Started"
 #' # https://github.com/stan-dev/rstan/wiki/RStan-Getting-Started
 #' 
-#' model_file <- system.file("extdata", "8schools.stan", package = "broom")
+#' model_file = system.file("extdata", "8schools.stan", package = "broom")
 #' 
-#' schools_dat <- list(J = 8, 
-#'                     y = c(28,  8, -3,  7, -1,  1, 18, 12),
-#'                     sigma = c(15, 10, 16, 11,  9, 11, 10, 18))
+#' schools_dat = list(J = 8, 
+#'                    y = c(28,  8, -3,  7, -1,  1, 18, 12),
+#'                    sigma = c(15, 10, 16, 11,  9, 11, 10, 18))
 #' 
-#' if (requireNamespace("rstan", quietly = TRUE)) {
+#' if (require("rstan", quietly = TRUE)) {
 #'   set.seed(2015)
 #'   rstan_example <- stan(file = model_file, data = schools_dat, 
 #'                         iter = 100, chains = 2)
@@ -35,7 +36,7 @@
 #' 
 #' }
 #' 
-#' if (requireNamespace("rstan", quietly = TRUE)) {
+#' if (require("rstan", quietly = TRUE)) {
 #'   # the object from the above code was saved as rstan_example.rda
 #'   infile <- system.file("extdata", "rstan_example.rda", package = "broom")
 #'   load(infile)
@@ -67,6 +68,7 @@ tidyMCMC <- function(x,
                      droppars = "lp__",
                      rhat = FALSE,
                      ess = FALSE,
+                     index = FALSE,
                      ...) {
     stan <- inherits(x, "stanfit")
     ss <- if (stan) as.matrix(x, pars = pars) else as.matrix(x)
@@ -82,9 +84,17 @@ tidyMCMC <- function(x,
     m <- switch(estimate.method,
                 mean = colMeans(ss),
                 median = apply(ss, 2, stats::median))
+    # Extract indexes and remove [] if requested
+    if (index){
+      ret <- data.frame(term0 = sub("\\[\\d+\\]", "", names(m)),
+                        index = as.integer(stringr::str_match(names(m), "\\[(\\d+)\\]")[,2]),
+                        estimate = m,
+                        std.error = apply(ss, 2, stats::sd))
 
-    ret <- data.frame(estimate = m,
-                      std.error = apply(ss, 2, stats::sd))
+    } else {
+      ret <- data.frame(estimate = m,
+                        std.error = apply(ss, 2, stats::sd))
+    }
     if (conf.int) {
         levs <- c((1 - conf.level) / 2, (1 + conf.level) / 2)
 
@@ -104,7 +114,8 @@ tidyMCMC <- function(x,
         if (rhat) ret$rhat <- summ[, "Rhat"]
         if (ess) ret$ess <- as.integer(round(summ[, "n_eff"]))
     }
-    return(fix_data_frame(ret))
+    fix_data_frame(ret)
+
 }
 
 

--- a/R/nlme_tidiers.R
+++ b/R/nlme_tidiers.R
@@ -139,9 +139,7 @@ augment.lme <- function(x, data = x$data, newdata, ...) {
 #' @export
 glance.lme <- function(x, ...) {
     ret <- unrowname(data.frame(sigma = x$sigma))
-    ret = finish_glance(ret, x)
-    ret$deviance = NA
-#    ret$deviance = -2 * x$logLik # Or better leave this out totally?
+    ret <- finish_glance(ret, x) # Sets deviance to NA
     ret
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -229,10 +229,9 @@ finish_glance <- function(ret, x) {
     ret$AIC <- tryCatch(stats::AIC(x), error = function(e) NULL)
     ret$BIC <- tryCatch(stats::BIC(x), error = function(e) NULL)
     
-    # special case for REML objects (better way?)
+    # Return NA as deviance, following comment by Brian Ripley
     if ("lmerMod" %in% class(x)) {
-        ret$deviance <- tryCatch(stats::deviance(x, REML=FALSE),
-                                 error = function(e) NULL)
+        ret$deviance <- NA
     } else {
         ret$deviance <- tryCatch(stats::deviance(x), error = function(e) NULL)
     }

--- a/tests/testthat/test-nlme.R
+++ b/tests/testthat/test-nlme.R
@@ -56,7 +56,7 @@ if (suppressPackageStartupMessages(require(nlme, quietly = TRUE))) {
     }
     
     testFit(lme(score ~ Machine, data = Machines, random = ~1 | Worker))
-    testFit(lme(score ~ Machine, data = Machines, random = ~1 | Worker))
+    testFit(lme(score ~ Machine, data = Machines, random = ~1 | Worker, method = "ML"))
     testFit(lme(score ~ Machine, data = Machines, random = ~1 | Worker / Machine))
     testFit(lme(pixel ~ day + day ^ 2, data = Pixel, random = list(Dog = ~day, Side = ~1)))
     testFit(lme(pixel ~ day + day ^ 2 + Side, data = Pixel, 

--- a/tests/testthat/test-rstan.R
+++ b/tests/testthat/test-rstan.R
@@ -1,0 +1,36 @@
+if (suppressPackageStartupMessages(require(rstan, quietly = TRUE))) {
+  context("nlme models")
+
+  infile <- system.file("extdata", "rstan_example.rda", package = "broom")
+  load(infile)
+
+  test_that("Correct columns are returned on default and with conf.int call", {
+           
+    t_default <- tidy(rstan_example)
+    expect_match(t_default$term, "eta\\[\\d\\]|mu|tau")
+    expect_equal(names(t_default), c("term", "estimate", "std.error"))
+
+    t_cf = tidy(rstan_example, conf.int = TRUE, pars = "theta")
+    
+    expect_match(t_cf$term, "theta\\[\\d\\]")
+    expect_equal(names(t_cf), c("term", "estimate", "std.error", "conf.low", "conf.high"))
+    
+  })        
+
+  test_that("Index columns are extracted when requested", {
+      
+      estimate.method = "mean"
+      conf.int = FALSE
+      conf.level = 0.95
+      conf.method = "quantile"
+      droppars = "lp__"
+      rhat = FALSE
+      ess = FALSE
+      index = TRUE
+      pars = c("eta", "theta")
+
+      t_index <- tidy(rstan_example, index = TRUE)
+      expect_match(t_index$term, "(eta|mu|tau)")
+      expect_equal(names(t_index), c("term", "term0", "index", "estimate", "std.error"))
+  })        
+}


### PR DESCRIPTION
Major change
Added index (TRUE, FALSE) to mcmc_tidiers. 

- If  index = FALSE (default), old behavior. 
- If index =  TRUE, rownames are unwrapped to columns term0 and index. For example, `eta[1]` has `term0 = "eta"` and `index = 1`.

Minor changes: 

- Replaced  <- by = in mcmc_tidiers (<- is deprecated for Stan code)

- Replaced `requireNamespace()` by `require`. In my setup (Windows) the first was not enough, even if it is preferred in the R-doc. Probably an import problem, but did not check details.

- Replaced `dontrun` with `donttest, so that at least on local builds the problem with examples will turn up.
 
