### PR TITLE
Fix inflate()

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -272,24 +272,33 @@ confint_tidy <- function(x, conf.level = .95, func = stats::confint, ...) {
 #' Expand a dataset to include all factorial combinations of one or more
 #' variables
 #'
-#' @param .data a tbl
+#' @param df a tbl
 #' @param ... arguments
 #' @param stringsAsFactors logical specifying if character vectors are
 #' converted to factors.
 #'
-#' @return A tbl, grouped by the arguments in \code{...}
+#' @return A tbl
 #'
 #' @import dplyr
 #'
 #' @export
-inflate <- function(.data, ..., stringsAsFactors = FALSE) {
+inflate <- function(df, ..., stringsAsFactors = FALSE) {
     ret <- expand.grid(..., stringsAsFactors = stringsAsFactors)
-    ret <- ret %>% group_by_(.dots = colnames(ret)) %>% do(.data)
-    if (!is.null(groups(.data))) {
-        ret <- ret %>% group_by_(.dots = groups(.data), add = TRUE)
+    
+    ret <- ret %>%
+        group_by_all() %>%
+        do(data = df) %>%
+        ungroup() %>%
+        unnest(data)
+    
+    if (!is.null(groups(df))) {
+        ret <- ret %>%
+            group_by_all()
     }
+    
     ret
 }
+
 
 
 # utility function from tidyr::col_name

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -280,6 +280,7 @@ confint_tidy <- function(x, conf.level = .95, func = stats::confint, ...) {
 #' @return A tbl
 #'
 #' @import dplyr
+#' @import tidyr
 #'
 #' @export
 inflate <- function(df, ..., stringsAsFactors = FALSE) {
@@ -289,7 +290,7 @@ inflate <- function(df, ..., stringsAsFactors = FALSE) {
         group_by_all() %>%
         do(data = df) %>%
         ungroup() %>%
-        unnest(data)
+        tidyr::unnest(data)
     
     if (!is.null(groups(df))) {
         ret <- ret %>%


### PR DESCRIPTION
Recently reran the [LOESS animation example](http://varianceexplained.org/files/loess.html). Used to run fine, but now I run into an error.

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(broom)
library(lattice)

ethanol %>%
  inflate(center = unique(ethanol$E)) %>%
  mutate(dist = abs(E - center))
#> Error in mutate_impl(.data, dots): Evaluation error: object 'E' not found.
```

The problem is that `inflate()` is no longer performing as expected. Rather than expanding the data frame to include all combinations of `center` with `ethanol`, it only creates the `center` column:

``` r
ethanol %>%
  inflate(center = unique(ethanol$E))
#> # A tibble: 83 x 1
#> # Groups:   center [83]
#>    center
#>     <dbl>
#>  1  0.535
#>  2  0.562
#>  3  0.568
#>  4  0.584
#>  5  0.601
#>  6  0.602
#>  7  0.608
#>  8  0.629
#>  9  0.637
#> 10  0.655
#> # ... with 73 more rows
```

I'm guessing it has something to do with `dplyr` and its new approach to tidy evaluation. The problem seems to occur in `ret <- ret %>% group_by_(.dots = colnames(ret)) %>% do(.data)`.

This PR modifies that line of code to make use of `group_by_all()` which seems to perform the same operation as `group_by_(.dots = colnames(ret))`. `.data` also seems to be reserved in the piped operation for the results of the previous chained function, so I rewrote it to use `unnest()` to expand the list-column and create a single `tbl`. With the revised function, we get the correct output:

``` r
ethanol %>%
  inflate(center = unique(ethanol$E))
#> # A tibble: 7,304 x 4
#>    center   NOx     C     E
#>     <dbl> <dbl> <dbl> <dbl>
#>  1  0.535 3.741    12 0.907
#>  2  0.535 2.295    12 0.761
#>  3  0.535 1.498    12 1.108
#>  4  0.535 2.881    12 1.016
#>  5  0.535 0.760    12 1.189
#>  6  0.535 3.120     9 1.001
#>  7  0.535 0.638     9 1.231
#>  8  0.535 1.170     9 1.123
#>  9  0.535 2.358    12 1.042
#> 10  0.535 0.606    12 1.215
#> # ... with 7,294 more rows
```