### PR TITLE
Logit

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -228,6 +228,21 @@ finish_glance <- function(ret, x) {
     ret$logLik <- tryCatch(as.numeric(stats::logLik(x)), error = function(e) NULL)
     ret$AIC <- tryCatch(stats::AIC(x), error = function(e) NULL)
     ret$BIC <- tryCatch(stats::BIC(x), error = function(e) NULL)
+    ret$hosmer <- tryCatch(
+        (x$null.deviance - x$deviance) / x$null.deviance,
+        error = function(e) NULL)
+    ret$cox <- tryCatch(
+        1 - exp((x$deviance - x$null.deviance) / 
+                    length(x$fitted.values)),
+        error = function(e) NULL)
+    ret$nagel <- tryCatch(
+        ret$cox / (1 - exp(-(x$null.deviance / length(x$fitted.values)))),
+        error = function(e) NULL)
+    ret$p.value <- tryCatch(
+        1 - pchisq(
+            (x$null.deviance - x$deviance),
+            (x$df.null - x$df.residual)),
+        error = function(e) NULL)
     
     # special case for REML objects (better way?)
     if ("lmerMod" %in% class(x)) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -217,6 +217,10 @@ augment_columns <- function(x, data, newdata, type, type.predict = type,
 #'   \item{logLik}{log likelihoods}
 #'   \item{AIC}{Akaike Information Criterion}
 #'   \item{BIC}{Bayesian Information Criterion}
+#'   \item{hosmer}{Hosmer and Lemeshow's pseudo Rsquare statistic}
+#'   \item{Cox}{Cox and Snell's pseudo Rsquare statistic}
+#'   \item{nagel}{Nagelkerke's pseudo Rsquare statistic}
+#'   \item{p.value}{P value}
 #'   \item{deviance}{deviance}
 #'   \item{df.residual}{residual degrees of freedom}
 #'   

--- a/man/finish_glance.Rd
+++ b/man/finish_glance.Rd
@@ -17,6 +17,10 @@ a one-row data frame with additional columns added, such as
   \item{logLik}{log likelihoods}
   \item{AIC}{Akaike Information Criterion}
   \item{BIC}{Bayesian Information Criterion}
+  \item{hosmer}{Hosmer and Lemeshow's pseudo Rsquare statistic}
+  \item{Cox}{Cox and Snell's pseudo Rsquare statistic}
+  \item{nagel}{Nagelkerke's pseudo Rsquare statistic}
+  \item{p.value}{P value}
   \item{deviance}{deviance}
   \item{df.residual}{residual degrees of freedom}
   
@@ -34,4 +38,3 @@ In one special case, deviance for objects of the
 \code{lmerMod} class from lme4 is computed with
 \code{deviance(x, REML=FALSE)}.
 }
-


### PR DESCRIPTION
I would like to include pseudo-R^2 and p.values for logit models, which I have added to the `finish_glance()` function.

I've added error catching but the new code fails when testing an ordinary `lm()` model. I can't tell if this is my new code, or errors already in the build.

If you have time could you help me incorporate these extra bits of logit information?