### PR TITLE
include NEWS.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^NEWS\.md$
 ^man-roxygen$
 ^revdep$
 ^cran-comments\.md$


### PR DESCRIPTION
`NEWS` is not included in `Materials` field in the package description. Maybe it is better to stop ignoring `NEWS.md`?

https://cran.r-project.org/package=broom