### PR TITLE
Try fallback to texreg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,7 +91,8 @@ Suggests:
     AER,
     muhaz,
     speedglm,
-    tibble
+    tibble,
+    texreg
 URL: http://github.com/tidyverse/broom
 BugReports: http://github.com/tidyverse/broom/issues
 VignetteBuilder: knitr

--- a/R/nls_tidiers.R
+++ b/R/nls_tidiers.R
@@ -56,7 +56,7 @@ tidy.nls <- function(x, conf.int = FALSE, conf.level = .95,
                      quick = FALSE, ...) {
     if (quick) {
         co <- stats::coef(x)
-        ret <- data.frame(term = names(co), estimate = unname(co))
+        ret <- data.frame(term = names(co), estimate = unname(co), stringsAsFactors = FALSE)
         return(ret)
     }
     

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -31,10 +31,12 @@ tidy.NULL <- function(x, ...) {
 
 #' Default tidying method
 #' 
-#' By default, tidy uses \code{as.data.frame} to convert its output. This is 
-#' dangerous, as it may fail with an uninformative error message.
-#' Generally tidy is intended to be used on structured model objects
-#' such as lm or htest for which a specific S3 object exists.
+#' If \code{\link[texreg]{texreg-package}} is available, then by default
+#' tidy attempts to use the \code{\link[texreg]{extract}} method to find 
+#' coefficients. Failing that, tidy uses \code{as.data.frame} to convert 
+#' its output. This is dangerous, as it may fail with an uninformative 
+#' error message. Generally tidy is intended to be used on structured model 
+#' objects such as lm or htest for which a specific S3 object exists.
 #' 
 #' If you know that you want to use \code{as.data.frame} on your untidy
 #' object, just use it directly.
@@ -46,6 +48,16 @@ tidy.NULL <- function(x, ...) {
 #' 
 #' @export
 tidy.default <- function(x, ...) {
+    args <- list(...)
+    if (requireNamespace('texreg', quietly = TRUE)) {
+        extract_method <- methods::selectMethod("extract", signature = class(x))
+        # we check this to make sure texreg doesn't call broom, leading to an 
+        # infinite regress:
+        if (! extract_method@defined@.Data == "ANY") {
+            texreg_obj <- texreg::extract(x)
+            return(texreg_to_tidy(texreg_obj, ...))   
+        }
+    }
     warning(paste("No method for tidying an S3 object of class",
                   class(x), ", using as.data.frame"))
     as.data.frame(x)

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -48,10 +48,9 @@ tidy.NULL <- function(x, ...) {
 #' 
 #' @export
 tidy.default <- function(x, ...) {
-    args <- list(...)
     if (requireNamespace("texreg", quietly = TRUE)) {
-        result <- tryCatch(methods::selectMethod("extract", signature = class(x)),
-            error = identity)
+        result <- tryCatch(methods::selectMethod("extract", 
+            signature = class(x)),error = identity)
         # we check this to make sure texreg doesn't call broom, leading to an 
         # infinite regress:
         if (! inherits(result, "error") && ! result@defined@.Data == "ANY") {

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -50,10 +50,11 @@ tidy.NULL <- function(x, ...) {
 tidy.default <- function(x, ...) {
     args <- list(...)
     if (requireNamespace('texreg', quietly = TRUE)) {
-        extract_method <- methods::selectMethod("extract", signature = class(x))
+        result <- tryCatch(methods::selectMethod("extract", signature = class(x)),
+            error = identity)
         # we check this to make sure texreg doesn't call broom, leading to an 
         # infinite regress:
-        if (! extract_method@defined@.Data == "ANY") {
+        if (class(result) != "try-error" && ! result@defined@.Data == "ANY") {
             texreg_obj <- texreg::extract(x)
             return(texreg_to_tidy(texreg_obj, ...))   
         }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -49,12 +49,12 @@ tidy.NULL <- function(x, ...) {
 #' @export
 tidy.default <- function(x, ...) {
     args <- list(...)
-    if (requireNamespace('texreg', quietly = TRUE)) {
+    if (requireNamespace("texreg", quietly = TRUE)) {
         result <- tryCatch(methods::selectMethod("extract", signature = class(x)),
             error = identity)
         # we check this to make sure texreg doesn't call broom, leading to an 
         # infinite regress:
-        if (class(result) != "try-error" && ! result@defined@.Data == "ANY") {
+        if (! inherits(result, "error") && ! result@defined@.Data == "ANY") {
             texreg_obj <- texreg::extract(x)
             return(texreg_to_tidy(texreg_obj, ...))   
         }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -319,3 +319,19 @@ col_name <- function (x, default = stop("Please supply column name", call. = FAL
         return(x)
     stop("Invalid column specification", call. = FALSE)
 }
+
+
+# function to convert a texreg object to a broom::tidy data frame
+texreg_to_tidy <- function(trobj, ...) {
+    # typical slots: @coef.names, @coef, @se, @pvalues @ci.low, @ci.up
+    # @gof.names @gof @gof.decimal @model.name
+    args <- list(...)
+    ret <- data.frame(term = trobj@coef.names, estimate = trobj@coef, std.error = trobj@se, 
+        p.value = trobj@pvalues, stringsAsFactors = FALSE)
+    if ("conf.int" %in% names(args)) {
+        ret$conf.low = trobj@ci.low
+        ret$conf.high = trobj@ci.up
+    }
+    
+    unrowname(ret)
+}

--- a/man/tidy.default.Rd
+++ b/man/tidy.default.Rd
@@ -15,10 +15,12 @@
 A data frame, from \code{as.data.frame} applied to the input x.
 }
 \description{
-By default, tidy uses \code{as.data.frame} to convert its output. This is 
-dangerous, as it may fail with an uninformative error message.
-Generally tidy is intended to be used on structured model objects
-such as lm or htest for which a specific S3 object exists.
+If \code{\link[texreg]{texreg-package}} is available, then by default
+tidy attempts to use the \code{\link[texreg]{extract}} method to find 
+coefficients. Failing that, tidy uses \code{as.data.frame} to convert 
+its output. This is dangerous, as it may fail with an uninformative 
+error message. Generally tidy is intended to be used on structured model 
+objects such as lm or htest for which a specific S3 object exists.
 }
 \details{
 If you know that you want to use \code{as.data.frame} on your untidy

--- a/tests/testthat/test-texreg-fallback.R
+++ b/tests/testthat/test-texreg-fallback.R
@@ -3,9 +3,7 @@
 context("texreg fallback")
 
 skip_without_texreg_and <- function (pkg = character(0)) {
-    if (! requireNamespace("texreg", quietly = TRUE)) skip(
-        "texreg not installed, skipping")
-    for (p in pkg) {
+    for (p in c("texreg", pkg)) {
         if (! requireNamespace(p, quietly = TRUE)) skip(
             paste("Package", p, "not installed, skipping"))
     }

--- a/tests/testthat/test-texreg-fallback.R
+++ b/tests/testthat/test-texreg-fallback.R
@@ -25,9 +25,6 @@ test_that("No infinite regress if texreg has no method either", {
     skip_without_texreg_and()
     foo <- 1:5
     class(foo) <- "unknown_to_broom_and_texreg"
-    as.data.frame.unknown_to_broom_and_texreg <- function (x, ...) data.frame(a = 1:5)
-    expect_warning(tidy(foo), "using as.data.frame")
+    # suppressWarnings avoids an earlier warning
+    expect_error(suppressWarnings(tidy(foo)), "cannot coerce .* to a data.frame")
 })
-    
-
-    

--- a/tests/testthat/test-texreg-fallback.R
+++ b/tests/testthat/test-texreg-fallback.R
@@ -20,6 +20,14 @@ test_that("fallback to texreg works", {
     check_tidy(res, exp.row = 3)
     expect_equal(res$term, c("(Intercept)", "sin(2 * pi * Time)", "cos(2 * pi * Time)"))
 })
+
+test_that("No infinite regress if texreg has no method either", {
+    skip_without_texreg_and()
+    foo <- 1:5
+    class(foo) <- "unknown_to_broom_and_texreg"
+    as.data.frame.unknown_to_broom_and_texreg <- function (x, ...) data.frame(a = 1:5)
+    expect_warning(tidy(foo), "using as.data.frame")
+})
     
 
     

--- a/tests/testthat/test-texreg-fallback.R
+++ b/tests/testthat/test-texreg-fallback.R
@@ -1,0 +1,25 @@
+# test fallback to texreg
+
+context("texreg fallback")
+
+skip_without_texreg_and <- function (pkg = character(0)) {
+    if (! requireNamespace("texreg", quietly = TRUE)) skip(
+        "texreg not installed, skipping")
+    for (p in pkg) {
+        if (! requireNamespace(p, quietly = TRUE)) skip(
+            paste("Package", p, "not installed, skipping"))
+    }
+}
+    
+test_that("fallback to texreg works", {
+    skip_without_texreg_and("nlme")
+    data("Ovary", package = "nlme")
+    fm1 <- nlme::gls(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
+        correlation = nlme::corAR1(form = ~ 1 | Mare))
+    expect_silent(res <- tidy(fm1))
+    check_tidy(res, exp.row = 3)
+    expect_equal(res$term, c("(Intercept)", "sin(2 * pi * Time)", "cos(2 * pi * Time)"))
+})
+    
+
+    

--- a/tests/testthat/test-texreg-fallback.R
+++ b/tests/testthat/test-texreg-fallback.R
@@ -2,15 +2,10 @@
 
 context("texreg fallback")
 
-skip_without_texreg_and <- function (pkg = character(0)) {
-    for (p in c("texreg", pkg)) {
-        if (! requireNamespace(p, quietly = TRUE)) skip(
-            paste("Package", p, "not installed, skipping"))
-    }
-}
     
 test_that("fallback to texreg works", {
-    skip_without_texreg_and("nlme")
+    if (! require("texreg")) skip("texreg not installed, skipping")
+    if (! require("nlme")) skip("nlme not installed, skipping")
     data("Ovary", package = "nlme")
     fm1 <- nlme::gls(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
         correlation = nlme::corAR1(form = ~ 1 | Mare))
@@ -20,7 +15,7 @@ test_that("fallback to texreg works", {
 })
 
 test_that("No infinite regress if texreg has no method either", {
-    skip_without_texreg_and()
+    if (! require("texreg")) skip("texreg not installed, skipping")
     foo <- 1:5
     class(foo) <- "unknown_to_broom_and_texreg"
     # suppressWarnings avoids an earlier warning


### PR DESCRIPTION
This is a first shot at using `texreg::extract` as a fallback. It changes the default tidy method. I haven't yet tried to do `glance`, want to see what you think of this approach first.

texreg itself falls back to `broom`; the code tries to check that this won't happen.