### PR TITLE
Improve error message formatting

### DIFF
--- a/R/augment.R
+++ b/R/augment.R
@@ -22,5 +22,5 @@ augment.NULL <- function(x, ...) data.frame()
 
 #' @export
 augment.default <- function(x, ...) {   
-    stop("augment doesn't know how to deal with data of class ", class(x), call. = FALSE)
+    stop("augment doesn't know how to deal with data of class ", class(x)[1], call. = FALSE)
 }

--- a/R/glance.R
+++ b/R/glance.R
@@ -14,5 +14,5 @@ glance.NULL <- function(x, ...) data.frame()
 
 #' @export
 glance.default <- function(x, ...) {   
-    stop("glance doesn't know how to deal with data of class ", class(x), call. = FALSE)
+    stop("glance doesn't know how to deal with data of class ", class(x)[1], call. = FALSE)
 }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -47,6 +47,6 @@ tidy.NULL <- function(x, ...) {
 #' @export
 tidy.default <- function(x, ...) {
     warning(paste("No method for tidying an S3 object of class",
-                  class(x), ", using as.data.frame"))
+                  class(x)[1], ", using as.data.frame"))
     as.data.frame(x)
 }

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -48,4 +48,8 @@ test_that("default augment throws error for unimplemented methods", {
     expect_error(augment(1))
     expect_error(augment(1L))
     expect_error(augment("a"))
+    
+    x <- 5; class(x) <- c("foo", "bar")
+    expect_error(augment(x), regexp="foo")
+    expect_error(augment(x), regexp="[^bar]")
 })

--- a/tests/testthat/test-glance.R
+++ b/tests/testthat/test-glance.R
@@ -9,4 +9,8 @@ test_that("default glance throws error for unimplemented methods", {
     expect_error(glance(1))
     expect_error(glance(1L))
     expect_error(glance("a"))
+    
+    x <- 5; class(x) <- c("foo", "bar")
+    expect_error(glance(x), regexp="foo")
+    expect_error(glance(x), regexp="[^bar]")
 })

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -145,4 +145,10 @@ test_that("tidy.NULL returns empty data frame", {
 test_that("tidy.default throws warning before turning into data.frame", {
     expect_warning(td <- tidy(raw(1)))
     check_tidy(td, exp.row = 1, exp.col = 1)
+    
+    x <- 5; class(x) <- c("foo", "bar")
+    # Since we haven't implemented as.data.frame.foo this throws both a
+    # warning and an error
+    expect_error(expect_warning(tidy(x), regexp="foo"))
+    expect_error(expect_warning(tidy(x), regexp="[^bar]"))
 })


### PR DESCRIPTION
For objects with multiple S3 classes, only
print the first in errors/warnings thrown
by the default methods of tidy, augment, & glance

Previous behavior:

```{r}
# my_fit is the output of glmnet(X, y)
> augment(my_fit)
Error: augment doesn't know how to deal with data of class elnetglmnet
```

New behavior:

```{r}
> augment(my_fit)
Error: augment doesn't know how to deal with data of class elnet
```