### PR TITLE
Remove `psych` dependency from data frame tidiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,9 @@ Authors@R: c(
     person("Jens", "Preussner", email = " jens.preussner@mpi-bn.mpg.de", role = "ctb"),
     person("Jay", "Hesselberth", email = "jay.hesselberth@gmail.com", role = "ctb"),
     person("Hadley", "Wickham", email = "hadley@rstudio.com", role = "ctb"),
-    person("Matthew", "Lincoln", email = "matthew.d.lincoln@gmail.com", role = "ctb"))
+    person("Matthew", "Lincoln", email = "matthew.d.lincoln@gmail.com", role = "ctb"),
+    person("Lukasz", "Komsta", email = "lukasz.komsta@umlub.pl", role = "ctb"),
+    person("Frederick", "Novometsky", role = "ctb"))
 Maintainer: David Robinson <admiral.david@gmail.com>
 Description: Convert statistical analysis objects from R into tidy data frames,
     so that they can more easily be combined, reshaped and otherwise processed
@@ -32,7 +34,6 @@ Imports:
     plyr,
     dplyr,
     tidyr,
-    psych,
     stringr,
     reshape2,
     nlme,


### PR DESCRIPTION
* Revamps the `tidy.data.frame` method to directly calculate the metrics previously calculated by `psych`.  
* Removes `psych` package from the `Imports` in `DESCRIPTION`.
* I'm not completely clear on the protocol here, but I pretty blatantly borrowed from the `moments` package to get calculations for skew and kurtosis.  I've added that source to the references in the documentation for `tidy.data.frame` and added the authors of `moments` to the authorship list in `DESCRIPTION`.  

See Issue #296 