### PR TITLE
Keep residuals for manova fits issue 307 Feature request

### DIFF
--- a/R/stats_tidiers.R
+++ b/R/stats_tidiers.R
@@ -238,8 +238,6 @@ tidy.manova <- function(x, test = "Pillai", ...) {
 
   nn <- c("df", test.name, "statistic", "num.df", "den.df", "p.value")
   ret <- fix_data_frame(summary(x, test = test, ...)$stats, nn)
-  # remove residuals row (doesn't have useful information)
-  ret <- ret[-nrow(ret), ]
   ret
 }
 

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -43,7 +43,7 @@ test_that("test.manova works", {
   npk2 <- within(npk, foo <- rnorm(24))
   npk2.aov <- manova(cbind(yield, foo) ~ block + N * P * K, npk2)
   td <- tidy(npk2.aov)
-  check_tidy(td, exp.row = 7, exp.col = 7)
+  check_tidy(td, exp.row = 8, exp.col = 7)
 })
 
 test_that("tidy.ts works", {


### PR DESCRIPTION
Removed a row that was deleting the residual information. 
Changed the test to include the extra row. 
I tried devtools::load_all() and it worked.
Then I installed from my github repo and it also worked. 
