### PR TITLE
Omit rows with all NA in confint_tidy()

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -270,9 +270,9 @@ confint_tidy <- function(x, conf.level = .95, func = stats::confint, ...) {
   # remove rows that are all NA. *not the same* as na.omit which checks
   # for any NA.
   all_na <- apply(ci, 1, function(x) all(is.na(x)))
-  ci <- ci[!all_na, ]
+  ci <- ci[!all_na,, drop = FALSE]
   colnames(ci) <- c("conf.low", "conf.high")
-  unrowname(as.data.frame(ci))
+  as_tibble(ci)
 }
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -263,15 +263,16 @@ finish_glance <- function(ret, x) {
 #' @export
 confint_tidy <- function(x, conf.level = .95, func = stats::confint, ...) {
   # avoid "Waiting for profiling to be done..." message for some models
-  CI <- suppressMessages(func(x, level = conf.level, ...))
-  if (is.null(dim(CI))) {
-    CI <- matrix(CI, nrow = 1)
+  ci <- suppressMessages(func(x, level = conf.level, ...))
+  if (is.null(dim(ci))) {
+    ci <- matrix(ci, nrow = 1)
   }
-  # remove rows that are all NA
-  allNA <- apply(CI, 1, function(x) all(is.na(x)))
-  CI <- CI[!allNA, ]
-  colnames(CI) <- c("conf.low", "conf.high")
-  unrowname(as.data.frame(CI))
+  # remove rows that are all NA. *not the same* as na.omit which checks
+  # for any NA.
+  all_na <- apply(ci, 1, function(x) all(is.na(x)))
+  ci <- ci[!all_na, ]
+  colnames(ci) <- c("conf.low", "conf.high")
+  unrowname(as.data.frame(ci))
 }
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -267,12 +267,9 @@ confint_tidy <- function(x, conf.level = .95, func = stats::confint, ...) {
   if (is.null(dim(CI))) {
     CI <- matrix(CI, nrow = 1)
   }
-  # Handle case if regression is rank deficient
-  p <- x$rank
-  if (!is.null(p) && !is.null(x$qr)) {
-    piv <- x$qr$pivot[seq_len(p)]
-    CI <- CI[piv, , drop = FALSE]
-  }
+  # remove rows that are all NA
+  allNA <- apply(CI, 1, function(x) all(is.na(x)))
+  CI <- CI[!allNA, ]
   colnames(CI) <- c("conf.low", "conf.high")
   unrowname(as.data.frame(CI))
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -267,6 +267,12 @@ confint_tidy <- function(x, conf.level = .95, func = stats::confint, ...) {
   if (is.null(dim(CI))) {
     CI <- matrix(CI, nrow = 1)
   }
+  # Handle case if regression is rank deficient
+  p <- x$rank
+  if (!is.null(p) && !is.null(x$qr)) {
+    piv <- x$qr$pivot[seq_len(p)]
+    CI <- CI[piv, , drop = FALSE]
+  }
   colnames(CI) <- c("conf.low", "conf.high")
   unrowname(as.data.frame(CI))
 }

--- a/tests/testthat/test-lm.R
+++ b/tests/testthat/test-lm.R
@@ -70,18 +70,21 @@ test_that("augment and glance do not support multiple responses", {
 
 test_that("tidy with confint drops rows of all NA", {
   
+  skip_if_not_installed("purrr")
+  library(purrr)
+  
   mtcars$cv_chunk <- c(
     1L, 1L, 2L, 1L, 1L, 3L, 1L, 1L, 3L, 1L, 1L, 2L, 3L, 3L, 3L, 2L,
     2L, 1L, 1L, 2L, 1L, 3L, 2L, 2L, 1L, 2L, 2L, 1L, 1L, 2L, 2L, 1L
   )
   
-  mtcars %>% 
-    filter(cv_chunk == 3) %>% 
-    lm(mpg ~ cyl * qsec + gear - cv_chunk, data = .)
+  fit_model <- function(data) {
+    lm(mpg ~ cyl * qsec + gear - cv_chunk, data = data)
+  }
   
   mtcars_model_list <- mtcars %>% 
     split(.$cv_chunk) %>% 
-    map(~lm(mpg ~ cyl * qsec + gear - cv_chunk, data = .))
+    map(fit_model)
   
   # this used to error, it should no longer
   expect_error(

--- a/tests/testthat/test-lm.R
+++ b/tests/testthat/test-lm.R
@@ -65,3 +65,34 @@ test_that("augment and glance do not support multiple responses", {
   expect_error(augment(mlmfit))
   expect_error(glance(mlmfit))
 })
+
+# regression tests for for tidy_confint NA issues, github issues 166, 241
+
+test_that("tidy with confint drops rows of all NA", {
+  
+  mtcars$cv_chunk <- c(
+    1L, 1L, 2L, 1L, 1L, 3L, 1L, 1L, 3L, 1L, 1L, 2L, 3L, 3L, 3L, 2L,
+    2L, 1L, 1L, 2L, 1L, 3L, 2L, 2L, 1L, 2L, 2L, 1L, 1L, 2L, 2L, 1L
+  )
+  
+  mtcars %>% 
+    filter(cv_chunk == 3) %>% 
+    lm(mpg ~ cyl * qsec + gear - cv_chunk, data = .)
+  
+  mtcars_model_list <- mtcars %>% 
+    split(.$cv_chunk) %>% 
+    map(~lm(mpg ~ cyl * qsec + gear - cv_chunk, data = .))
+  
+  # this used to error, it should no longer
+  expect_error(
+    map(mtcars_model_list, ~broom::tidy(.x, conf.int=TRUE)),
+    NA
+  )
+  
+  # should not contain any NA values
+  expect_error(
+    td <- map(mtcars_model_list, ~broom::confint_tidy(.x))[[3]],
+    NA
+  )
+  expect_false(anyNA(td))
+})


### PR DESCRIPTION
Following the discussion at #324, I re-ran all the problematic examples and as far as I can tell they all work as intended (omitting NA rows). The exception is `confint_tidy()`. I tried adding the same code for rank-deficient models from `process_lm()`, but some tidiers call `confint_tidy()` with objects that are not regression models, and therefore lack components like `rank` and `qr` (e.g. bbmle). So instead I checked for NA rows in the result, and eliminate those. 

The only issue I can see is that there is no way to tell which rows were eliminated, because `confint_tidy()` just returns two columns with the confidence intervals. This is quite different from other `tidy()` results which always include the names of the relevant terms. 