### PR TITLE
tidy_emmeans handles contrasts when column names have dashes

### DIFF
--- a/R/emmeans_tidiers.R
+++ b/R/emmeans_tidiers.R
@@ -115,7 +115,7 @@ tidy_emmeans <- function(x, ...) {
     all(stringr::str_detect(ret$contrast, " - "))) {
     ret <- tidyr::separate_(ret, "contrast",
       c("level1", "level2"),
-      sep = "-"
+      sep = " - "
     )
   }
 

--- a/R/emmeans_tidiers.R
+++ b/R/emmeans_tidiers.R
@@ -120,5 +120,5 @@ tidy_emmeans <- function(x, ...) {
   }
 
   colnames(ret) <- plyr::revalue(colnames(ret), repl, warn_missing = FALSE)
-  as_tibble(ret)
+  tibble::as_tibble(ret)
 }

--- a/R/emmeans_tidiers.R
+++ b/R/emmeans_tidiers.R
@@ -120,5 +120,5 @@ tidy_emmeans <- function(x, ...) {
   }
 
   colnames(ret) <- plyr::revalue(colnames(ret), repl, warn_missing = FALSE)
-  ret
+  as_tibble(ret)
 }

--- a/tests/testthat/test-lsmeans.R
+++ b/tests/testthat/test-lsmeans.R
@@ -5,8 +5,9 @@ oranges_lm1 <- lm(sales1 ~ price1 + price2 + day + store, data = oranges)
 oranges_rg1 <- ref.grid(oranges_lm1)
 marginal <- lsmeans(oranges_rg1, "day")
 # generate dataset with dashes
-marginal_dashes <- data_frame(y=rnorm(100), x=rep(c("Single", "Double-Barrelled"), 50)) %>% 
-  lm(y~x, data=.) %>% lsmeans::lsmeans(., ~x) %>% 
+marginal_dashes <- data_frame(y = rnorm(100),
+                              x = rep(c("Single", "Double-Barrelled"), 50)) %>% 
+  lm(y ~ x, data = .) %>% lsmeans::lsmeans(., ~ x) %>% 
   lsmeans::contrast(., "pairwise")
 
 test_that("lsmobj tidiers work", {

--- a/tests/testthat/test-lsmeans.R
+++ b/tests/testthat/test-lsmeans.R
@@ -4,6 +4,10 @@ suppressPackageStartupMessages(library(lsmeans))
 oranges_lm1 <- lm(sales1 ~ price1 + price2 + day + store, data = oranges)
 oranges_rg1 <- ref.grid(oranges_lm1)
 marginal <- lsmeans(oranges_rg1, "day")
+# generate dataset with dashes
+marginal_dashes <- data_frame(y=rnorm(100), x=rep(c("Single", "Double-Barrelled"), 50)) %>% 
+  lm(y~x, data=.) %>% lsmeans::lsmeans(., ~x) %>% 
+  lsmeans::contrast(., "pairwise")
 
 test_that("lsmobj tidiers work", {
   td <- tidy(marginal)
@@ -18,4 +22,9 @@ test_that("ref.grid tidiers work", {
 test_that("pairwise contrasts work", {
   td <- tidy(contrast(marginal, method = "pairwise"))
   check_tidy(td, exp.row = 15, exp.col = 7)
+})
+
+test_that("pairwise contrasts with dash names work", {
+  td <- tidy(marginal_dashes)
+  check_tidy(td, exp.row = 1, exp.col = 7)
 })


### PR DESCRIPTION
+ changed sep="-" to sep=" - " in separate_ call in tidy_emmeans
+ return a tibble from tidy_emmeans
+ add test data and test to test_lsmeans.R

Output looks like

``` r
suppressMessages(library(tidyverse))
suppressMessages(library(broom))
suppressMessages(library(lsmeans))
data_frame(y = rnorm(100), x = rep(c("Single", "Double-Barrelled"), 50)) %>% 
  lm(y ~ x, data = .) %>% lsmeans::lsmeans(., ~x) %>% lsmeans::contrast(., 
  "pairwise") %>% tidy %>% print()
#> # A tibble: 1 x 7
#>   level1           level2 estimate std.error    df statistic p.value
#> * <chr>            <chr>     <dbl>     <dbl> <dbl>     <dbl>   <dbl>
#> 1 Double-Barrelled Single   0.0617     0.187    98     0.329   0.743
```
