### PR TITLE
Accommodate single predictor models in tidy.rq and tidy.rqs. Fixes #354

### DIFF
--- a/R/rq_tidiers.R
+++ b/R/rq_tidiers.R
@@ -24,9 +24,11 @@ NULL
 #' as `conf.level` although the specification is inverted
 #' @param \dots other arguments passed on to `summary.rq`
 #'
-#' @details If `se.type != "rank"` and `conf.int = TRUE` confidence
-#' intervals are calculated by `summary.rq`. Otherwise they are standard t
-#' based intervals.
+#' @details If `se.type = "rank"` confidence intervals are calculated by 
+#' `summary.rq`. When only a single predictor is included in the model, 
+#' no confidence intervals are calculated and the confidence limits are set to NA. 
+#' If `se.type != 'rank'` and `conf.int = TRUE`, confidence intervals 
+#' are standard t based intervals.
 #'
 #' @return `tidy.rq` returns a data frame with one row for each coefficient.
 #' The columns depend upon the confidence interval method selected.
@@ -253,6 +255,11 @@ process_rq <- function(rq_obj, se.type = "rank",
   nn <- c("estimate", "std.error", "statistic", "p.value")
   co <- as.data.frame(rq_obj[["coefficients"]])
   if (se.type == "rank") {
+    # if only a single predictor is included, confidence interval is not calculated
+    # set to NA to preserve dimensions of object
+    if (1 == ncol(co)) {
+      co <- cbind(co, NA, NA)
+    } 
     co <- setNames(co, c("estimate", "conf.low", "conf.high"))
     conf.int <- FALSE
   } else {

--- a/man/rq_tidiers.Rd
+++ b/man/rq_tidiers.Rd
@@ -120,9 +120,11 @@ on the fitted values and residuals, and construct a glance of
 the model's statistics.
 }
 \details{
-If \code{se.type != "rank"} and \code{conf.int = TRUE} confidence
-intervals are calculated by \code{summary.rq}. Otherwise they are standard t
-based intervals.
+If \code{se.type = "rank"} confidence intervals are calculated by
+\code{summary.rq}. When only a single predictor is included in the model,
+no confidence intervals are calculated and the confidence limits are set to NA.
+If \code{se.type != 'rank'} and \code{conf.int = TRUE}, confidence intervals
+are standard t based intervals.
 
 Only models with a single \code{tau} value may be passed.
 For multiple values, please use a \code{\link[purrr:map]{purrr::map()}} workflow instead, e.g.\preformatted{taus %>%

--- a/tests/testthat/test-rq.R
+++ b/tests/testthat/test-rq.R
@@ -9,6 +9,10 @@ test_that("rq tidiers work", {
   td <- tidy(fit)
   check_tidy(td, exp.row = 4, exp.col = 5)
 
+  single_covariate_fit <- rq(stack.loss ~ 1, .5)
+  td <- tidy(single_covariate_fit)
+  check_tidy(td, exp.row = 1, exp.col = 5)
+
   td <- tidy(fit, se.type = "iid")
   check_tidy(td, exp.row = 4, exp.col = 8)
 
@@ -30,6 +34,10 @@ test_that("rqs tidiers work", {
   fit <- rq(Ozone ~ ., data = airquality, tau = 1:19 / 20)
   td <- tidy(fit)
   check_tidy(td, exp.row = 114, exp.col = 5)
+
+  single_covariate_fit <- rq(Ozone ~ Temp - 1, data = airquality, tau = 1:19 / 20)
+  td <- tidy(single_covariate_fit)
+  check_tidy(td, exp.row = 19, exp.col = 5)
 
   rqs_glance_error <- paste("`glance` cannot handle objects of class 'rqs',",
                             "i.e. models with more than one tau value. Please",


### PR DESCRIPTION
I've tried to tackle #354 by adding columns `conf.low` and `conf.high` set to `NA`, and added two new test cases to catch the old bug. In the process I also discovered a typo in the documentation about how confidence intervals are calculated when `se.type = 'rank'`, so I fixed that and added details about the new implementation.